### PR TITLE
Update yarn to 1.14 to fix babel dependencies

### DIFF
--- a/voyager_node/Dockerfile
+++ b/voyager_node/Dockerfile
@@ -2,6 +2,6 @@ FROM circleci/node:10.15
 
 USER root
 
-RUN npm -g uninstall yarn && npm -g install yarn@1.13.0
+RUN npm -g uninstall yarn && npm -g install yarn@1.14.0
 
 USER circleci

--- a/voyager_node_browser/Dockerfile
+++ b/voyager_node_browser/Dockerfile
@@ -2,6 +2,6 @@ FROM circleci/node:10.15-browsers
 
 USER root
 
-RUN npm -g uninstall yarn && npm -g install yarn@1.13.0
+RUN npm -g uninstall yarn && npm -g install yarn@1.14.0
 
 USER circleci


### PR DESCRIPTION
- yarn 1.13 had some issues managing dependencies, this was fixed in 1.14